### PR TITLE
memmap embeddings and labels

### DIFF
--- a/heareval/embeddings/task_embeddings.py
+++ b/heareval/embeddings/task_embeddings.py
@@ -264,6 +264,9 @@ def memmap_embeddings(
         else:
             raise ValueError(f"Unknown embedding type: {metadata['embedding_type']}")
 
+    open(
+        embed_dir.joinpath(task_name, f"{split_name}.embedding-dimensions.json"), "wt"
+    ).write(json.dumps((nembeddings, ndim)))
     embedding_memmap = np.memmap(
         filename=embed_dir.joinpath(task_name, f"{split_name}.embeddings.npy"),
         dtype=dtype,

--- a/heareval/embeddings/task_embeddings.py
+++ b/heareval/embeddings/task_embeddings.py
@@ -228,6 +228,82 @@ def get_labels_for_timestamps(labels: List, timestamps: np.ndarray) -> List:
     return timestamp_labels
 
 
+def memmap_embeddings(
+    outdir: Path,
+    prng: random.Random,
+    metadata: Dict,
+    split_name: str,
+    embed_dir: Path,
+    task_name: str,
+):
+    """
+    Memmap all the embeddings to one file, and pickle all the labels.
+    (We assume labels can fit in memory.)
+    TODO: This writes things to disk double, we could clean that up after.
+    We might also be able to get away with writing to disk only once.
+    """
+    embedding_files = list(outdir.glob("*.embedding.npy"))
+    prng.shuffle(embedding_files)
+
+    # First count the number of embeddings total
+    nembeddings = 0
+    ndim = None
+    dtype = None
+    for embedding_file in tqdm(embedding_files):
+        emb = np.load(embedding_file)
+        if metadata["embedding_type"] == "scene":
+            assert emb.ndim == 1
+            nembeddings += 1
+            ndim = emb.shape[0]
+            dtype = emb.dtype
+        elif metadata["embedding_type"] == "event":
+            assert emb.ndim == 2
+            nembeddings += emb.shape[0]
+            ndim = emb.shape[1]
+            dtype = emb.dtype
+        else:
+            raise ValueError(f"Unknown embedding type: {metadata['embedding_type']}")
+
+    embedding_memmap = np.memmap(
+        filename=embed_dir.joinpath(task_name, f"{split_name}.embeddings.npy"),
+        dtype=dtype,
+        mode="w+",
+        shape=(nembeddings, ndim),
+    )
+    idx = 0
+    labels = []
+    for embedding_file in tqdm(embedding_files):
+        emb = np.load(embedding_file)
+        lbl = json.load(
+            open(str(embedding_file).replace("embedding.npy", "target-labels.json"))
+        )
+        if metadata["embedding_type"] == "scene":
+            assert emb.ndim == 1
+            embedding_memmap[idx] = emb
+            # This is janky AF. The format is inconsistent with event embeddings
+            # AND its multiclass not multilabel. Honestly this should just be a list of labels.
+            labels.append([lbl])
+            idx += 1
+        elif metadata["embedding_type"] == "event":
+            assert emb.ndim == 2
+            embedding_memmap[idx : idx + emb.shape[0]] = emb
+            assert emb.shape[0] == len(lbl)
+            labels += lbl
+            idx += emb.shape[0]
+        else:
+            raise ValueError(f"Unknown embedding type: {metadata['embedding_type']}")
+    # Write changes to disk
+    embedding_memmap.flush()
+    # TODO: Convert labels to indices?
+    pickle.dump(
+        labels,
+        open(
+            embed_dir.joinpath(task_name, f"{split_name}.target-labels.pkl"),
+            "wb",
+        ),
+    )
+
+
 def task_embeddings(embedding: Embedding, task_path: Path):
     prng = random.Random()
     prng.seed(0)
@@ -296,77 +372,6 @@ def task_embeddings(embedding: Embedding, task_path: Path):
                     f"Unknown embedding type: {metadata['embedding_type']}"
                 )
 
-        # Memmap all the embeddings to one file,
-        # and pickle all the labels.
-        # (We assume labels can fit in memory.)
-        # TODO: This writes things to disk double,
-        # we could clean that up after. We might also be able to get
-        # away with writing to disk only once.
-        embedding_files = list(outdir.glob("*.embedding.npy"))
-        prng.shuffle(embedding_files)
-
-        # First count the number of embeddings total
-        nembeddings = 0
-        ndim = None
-        dtype = None
-        for embedding_file in tqdm(embedding_files):
-            emb = np.load(embedding_file)
-            if metadata["embedding_type"] == "scene":
-                assert emb.ndim == 1
-                nembeddings += 1
-                ndim = emb.shape[0]
-                dtype = emb.dtype
-            elif metadata["embedding_type"] == "event":
-                assert emb.ndim == 2
-                nembeddings += emb.shape[0]
-                ndim = emb.shape[1]
-                dtype = emb.dtype
-            else:
-                raise ValueError(
-                    f"Unknown embedding type: {metadata['embedding_type']}"
-                )
-
-        embedding_memmap = np.memmap(
-            filename=embed_dir.joinpath(
-                task_path.name, f"{split['name']}.embeddings.npy"
-            ),
-            dtype=dtype,
-            mode="w+",
-            shape=(nembeddings, ndim),
-        )
-        idx = 0
-        labels = []
-        for embedding_file in tqdm(embedding_files):
-            emb = np.load(embedding_file)
-            lbl = json.load(
-                open(str(embedding_file).replace("embedding.npy", "target-labels.json"))
-            )
-            if metadata["embedding_type"] == "scene":
-                assert emb.ndim == 1
-                embedding_memmap[idx] = emb
-                # This is janky AF. The format is inconsistent with event embeddings
-                # AND its multiclass not multilabel. Honestly this should just be a list of labels.
-                labels.append([lbl])
-                idx += 1
-            elif metadata["embedding_type"] == "event":
-                assert emb.ndim == 2
-                embedding_memmap[idx : idx + emb.shape[0]] = emb
-                assert emb.shape[0] == len(lbl)
-                labels += lbl
-                idx += emb.shape[0]
-            else:
-                raise ValueError(
-                    f"Unknown embedding type: {metadata['embedding_type']}"
-                )
-        # Write changes to disk
-        embedding_memmap.flush()
-        # TODO: Convert labels to indices?
-        pickle.dump(
-            labels,
-            open(
-                embed_dir.joinpath(
-                    task_path.name, f"{split['name']}.target-labels.pkl"
-                ),
-                "wb",
-            ),
+        memmap_embeddings(
+            outdir, prng, metadata, split["name"], embed_dir, task_path.name
         )


### PR DESCRIPTION
This will write embeddings to a memmap'ed file and labels to a single pickle'd file. This will make it easier to iterate over them quickly when learning the downstream predictor.

A few gotchas come up:
* The label format is inconsistent and weird between scenes and timestamps. Also scene labels are multiclass (one label) not lists. This isn't flexible. #124 I mean maybe this is okay tho, because for multiclass we want to return a tensor that is a single long and for multilabel we want to return a one hot tensor. (We can't have variable length rows in a tensor.)
* Once the files are memmap'ed it's slow to partition the examples into train and validation. I think luigi should split upstream into train and validation set for consistency. #94 