### PR TITLE
Event eval

### DIFF
--- a/heareval/evaluation/task_evaluation.py
+++ b/heareval/evaluation/task_evaluation.py
@@ -79,7 +79,7 @@ class MacroAUC(MetricFunction):
     def __call__(
         self, predictions: np.ndarray, targets: List, **kwargs
     ) -> Dict[str, float]:
-        return {"auc": None}
+        # return {"auc": None}
         # Dictionary of labels and integer idx: {label -> idx}
         label_vocab = self.label_vocab_as_dict(key="label")
 

--- a/heareval/evaluation/task_evaluation.py
+++ b/heareval/evaluation/task_evaluation.py
@@ -7,13 +7,16 @@ TODO: This is a start on this file. Still need to add a bunch of metrics for the
     Would it make sense to move all the metric functions over to a file called metrics?
 """
 
+from functools import partial
 import json
 from pathlib import Path
 import pickle
-from typing import Dict, List
+from typing import Dict, List, Tuple
 
+from dcase_util.containers import MetaDataContainer
 import numpy as np
 import pandas as pd
+import sed_eval
 import sklearn.metrics
 import torch
 
@@ -63,22 +66,98 @@ def macroauc(
     return {"macroauc": sklearn.metrics.roc_auc_score(y_true, predictions)}
 
 
+def sed_eval_event_container(x: Dict) -> MetaDataContainer:
+    # Reformat event list for sed_eval
+    reference_events = []
+    for filename, event_list in x.items():
+        for event in event_list:
+            reference_events.append(
+                {
+                    # Convert from ms to seconds for sed_eval
+                    "event_label": event["label"],
+                    "event_onset": event["start"] / 1000.0,
+                    "event_offset": event["end"] / 1000.0,
+                    "file": filename,
+                }
+            )
+    return MetaDataContainer(reference_events)
+
+
+def event_based_metrics(
+    predictions,
+    targets: Dict,
+    label_vocab=pd.DataFrame,
+    tolerance=0.200,
+    onset=True,
+    offset=True,
+):
+    """
+    event-based metrics - the ground truth and system output are compared at
+    event instance level;
+    https://tut-arg.github.io/sed_eval/sound_event.html#sound-event-detection
+    """
+    # Containers of events for sed_eval
+    reference_event_list = sed_eval_event_container(targets)
+    estimated_event_list = sed_eval_event_container(predictions)
+
+    metrics = sed_eval.sound_event.EventBasedMetrics(
+        event_label_list=list(label_vocab["label"]),
+        t_collar=tolerance,
+        evaluate_onset=onset,
+        evaluate_offset=offset,
+    )
+
+    for filename in predictions:
+        metrics.evaluate(
+            reference_event_list=reference_event_list.filter(filename=filename),
+            estimated_event_list=estimated_event_list.filter(filename=filename),
+        )
+
+    # This (and segment_based_metrics) return a pretty large selection of metrics. We
+    # might want to add a task_metadata option to filter these for the specific
+    # metric that we are going to use to evaluate the task.
+    overall_metrics = metrics.results_overall_metrics()
+    return overall_metrics
+
+
+def segment_based_metrics(
+    predictions, targets: Dict, label_vocab=pd.DataFrame, time_resolution=1.0
+):
+    """
+    segment-based metrics - the ground truth and system output are compared in a
+    fixed time grid; sound events are marked as active or inactive in each segment;
+    https://tut-arg.github.io/sed_eval/sound_event.html#sound-event-detection
+    """
+    # Containers of events for sed_eval
+    reference_event_list = sed_eval_event_container(targets)
+    estimated_event_list = sed_eval_event_container(predictions)
+
+    metrics = sed_eval.sound_event.SegmentBasedMetrics(
+        event_label_list=list(label_vocab["label"]), time_resolution=time_resolution
+    )
+
+    for filename in predictions:
+        metrics.evaluate(
+            reference_event_list=reference_event_list.filter(filename=filename),
+            estimated_event_list=estimated_event_list.filter(filename=filename),
+        )
+
+    overall_metrics = metrics.results_overall_metrics()
+    return overall_metrics
+
+
 # TODO: Add additional metrics
 
-available_metrics = {"top1_error": top1_error, "macroauc": macroauc}
+available_metrics = {
+    "top1_error": top1_error,
+    "macroauc": macroauc,
+    "event_based": event_based_metrics,
+    "onset_only_event_based": partial(event_based_metrics, offset=False),
+    "segment_based": segment_based_metrics,
+}
 
 
-def task_evaluation(task_path: Path):
-
-    metadata = json.load(task_path.joinpath("task_metadata.json").open())
-    label_vocab = pd.read_csv(task_path.joinpath("labelvocabulary.csv"))
-
-    embedding_type = metadata["embedding_type"]
-
-    if "evaluation" not in metadata:
-        print(f"Task {task_path.name} has no evaluation config.")
-        return
-
+def get_scene_based_prediction_files(task_path: Path) -> Tuple[np.ndarray, List]:
     # Predictions are currently torch tensors -- should we convert to np arrays before
     # pickling?
     predictions = pickle.load(
@@ -96,19 +175,50 @@ def task_evaluation(task_path: Path):
 
     targets = pickle.load(task_path.joinpath("test.target-labels.pkl").open("rb"))
 
-    # TODO: Check shape of predictions vs label_vocab
-
     # What other types could we receive as targets?
     assert isinstance(targets, list)
 
     # Make sure we have the same number of predictions as targets
     assert len(predictions) == len(targets)
 
+    return predictions, targets
+
+
+def get_event_based_prediction_files(task_path: Path) -> Tuple[Dict, Dict]:
+    # For event based embeddings we load JSON files of the labeled sound events
+    predictions = json.load(task_path.joinpath("test.predictions.json").open())
+    targets = json.load(task_path.joinpath("test.json").open())
+    assert isinstance(predictions, dict)
+    assert isinstance(targets, dict)
+    for filename in predictions:
+        assert filename in targets
+
+    return predictions, targets
+
+
+def task_evaluation(task_path: Path):
+
+    metadata = json.load(task_path.joinpath("task_metadata.json").open())
+    label_vocab = pd.read_csv(task_path.joinpath("labelvocabulary.csv"))
+
+    embedding_type = metadata["embedding_type"]
+
+    if "evaluation" not in metadata:
+        print(f"Task {task_path.name} has no evaluation config.")
+        return
+
+    if embedding_type == "scene":
+        predictions, targets = get_scene_based_prediction_files(task_path)
+    elif embedding_type == "event":
+        predictions, targets = get_event_based_prediction_files(task_path)
+    else:
+        raise ValueError(f"Unknown embedding type received: {embedding_type}")
+
     metrics = metadata["evaluation"]
     results = {}
     for metric in metrics:
         print("  -", metric)
         new_results = available_metrics[metric](predictions, targets, label_vocab)
-        results.update(new_results)
+        results.update({metric: new_results})
 
     return results

--- a/heareval/evaluation/task_evaluation.py
+++ b/heareval/evaluation/task_evaluation.py
@@ -11,7 +11,7 @@ from functools import partial
 import json
 from pathlib import Path
 import pickle
-from typing import Any, Dict, List, Tuple
+from typing import Any, Callable, Collection, Dict, List, Tuple
 
 
 from dcase_util.containers import MetaDataContainer
@@ -134,7 +134,7 @@ class SoundEventMetric(MetricFunction):
     """
 
     # Metric class must be defined in inheriting classes
-    metric_class = None
+    metric_class: sed_eval.sound_event.SoundEventMetrics = None
 
     def __init__(
         self, task_metadata: Dict, label_vocab: pd.DataFrame, params: Dict = None
@@ -143,7 +143,7 @@ class SoundEventMetric(MetricFunction):
         self.params = params if params is not None else {}
         assert self.metric_class is not None
 
-    def __call__(self, predictions: Dict, targets: Dict):
+    def __call__(self, predictions: Dict, targets: Dict, **kwargs):
         # Containers of events for sed_eval
         reference_event_list = self.sed_eval_event_container(targets)
         estimated_event_list = self.sed_eval_event_container(predictions)
@@ -206,7 +206,7 @@ class EventBasedMetric(SoundEventMetric):
     metric_class = sed_eval.sound_event.EventBasedMetrics
 
 
-available_metrics = {
+available_metrics: Dict[str, Callable] = {
     "top1_error": Top1Error,
     "macroauc": MacroAUC,
     "chroma_error": ChromaError,
@@ -266,6 +266,8 @@ def task_evaluation(task_path: Path):
         return
 
     embedding_type = metadata["embedding_type"]
+    predictions: Collection = []
+    targets: Collection = []
     if embedding_type == "scene":
         predictions, targets = get_scene_based_prediction_files(task_path)
     elif embedding_type == "event":

--- a/heareval/evaluation/task_evaluation.py
+++ b/heareval/evaluation/task_evaluation.py
@@ -79,6 +79,7 @@ class MacroAUC(MetricFunction):
     def __call__(
         self, predictions: np.ndarray, targets: List, **kwargs
     ) -> Dict[str, float]:
+        return {"auc": None}
         # Dictionary of labels and integer idx: {label -> idx}
         label_vocab = self.label_vocab_as_dict(key="label")
 
@@ -278,6 +279,6 @@ def task_evaluation(task_path: Path):
         print("  -", metric)
         metric_function = available_metrics[metric](metadata, label_vocab)
         new_results = metric_function(predictions, targets)
-        results.update(new_results)
+        results.update({metric: new_results})
 
     return results

--- a/heareval/evaluation/task_evaluation.py
+++ b/heareval/evaluation/task_evaluation.py
@@ -11,7 +11,7 @@ from functools import partial
 import json
 from pathlib import Path
 import pickle
-from typing import Dict, List, Tuple
+from typing import Callable, Dict, List, Tuple
 
 from dcase_util.containers import MetaDataContainer
 import numpy as np
@@ -148,7 +148,7 @@ def segment_based_metrics(
 
 # TODO: Add additional metrics
 
-available_metrics = {
+available_metrics: Dict[str, Callable] = {
     "top1_error": top1_error,
     "macroauc": macroauc,
     "event_based": event_based_metrics,

--- a/heareval/tasks/dcase2016_task2.py
+++ b/heareval/tasks/dcase2016_task2.py
@@ -45,8 +45,9 @@ config = {
         {"name": "train", "max_files": 10},
         {"name": "test", "max_files": 10},
     ],
-    # TODO: Add metrics
-    "evaluation": [],
+    # DCASE2016 task 2 used the segment-based total error rate as their main metric
+    # and then the onset only event based F1 as their secondary metric.
+    "evaluation": ["segment_based", "onset_only_event_based"],
 }
 
 


### PR DESCRIPTION
Sound event detection metrics from sed_eval. Implements both segment-based and event-based metrics that were used in DCASE2016 Task2. They used segment-based total error and onset-only event-based f1. This returns all segment-based and event-based metrics so we may need to filter these -- perhaps a task-config var?

Depends on the event predictions saved as JSON files in #149 