### PR TITLE
Add sampled dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,13 @@ mean meadian and certain (10, 25, 75, 90) percentile durations.
 This is helpful in getting a quick glance of the audio files in a folder and 
 helps in decideing the preprocessing configurations.
 
+For development, there is a sampler which could be used to generate small corpuses for testing of each task
+```
+python -m heareval.tasks.sampler <taskname>
+```
+Supported task name are speech_commands, nsynth_pitch and dcase2016_task2
+Sampled small version of the tasks can be found here: [Downsampled HEAR Open Tasks](https://github.com/turian/hear2021-open-tasks-downsampled)
+
 ### Computing embeddings
 
 Once a set of tasks has been generated, embeddings can be computed using any audio

--- a/README.md
+++ b/README.md
@@ -35,8 +35,9 @@ For DCASE 2016, Task 2 (sound event detection):
 python3 -m heareval.tasks.runner dcase2016_task2
 ```
 
-These commands will download and preprocess the entire dataset. An intermediary dir
-call `_workdir` will be created, and then a final directory called `tasks` will contain
+These commands will download and preprocess the entire dataset. An intermediary directory
+defined by the option `luigi-dir`(default `_workdir`) will be created, and then a 
+final directory defined by the option `tasks-dir` (default `tasks`) will contain
 the completed dataset.
 
 Options:
@@ -50,6 +51,12 @@ Options:
   
   --small       FLAG     If passed, the task will run on a small-version of the 
                          data.
+
+  --luigi-dir   STRING   Path to dir to store the intermediate luigi task outputs.
+                         By default this is set to _workdir in the module root directory
+
+  --tasks-dir   STRING   Path to dir to store the final task outputs.
+                         By default this is set to tasks in the module root directory
 ```
 The small flag runs the preprocessing pipeline on a small version of each dataset stored at [Downsampled HEAR Open Tasks](https://github.com/turian/hear2021-open-tasks-downsampled). This is used for development and continuous integration tests for the pipeline. These small versions of the data can be generated deterministically with the following command:
 ```

--- a/README.md
+++ b/README.md
@@ -48,10 +48,14 @@ Options:
   --sample-rate INTEGER  Perform resampling only to this sample rate. By
                          default we resample to 16000, 22050, 44100, 48000.
   
-  --small       BOOL     If True, the task will run on a small-version of the 
+  --small       FLAG     If passed, the task will run on a small-version of the 
                          data.
 ```
-[Link to small version of data](https://github.com/turian/hear2021-open-tasks-downsampled)
+The small flag runs the preprocessing pipeline on a small version of each dataset stored at [Downsampled HEAR Open Tasks](https://github.com/turian/hear2021-open-tasks-downsampled). This is used for development and continuous integration tests for the pipeline. These small versions of the data can be generated deterministically with the following command:
+```
+python -m heareval.tasks.sampler <taskname>
+```
+Supported task name are speech_commands, nsynth_pitch and dcase2016_task2.
 
 Additionally, to check the stats of an audio directory:
 ```
@@ -61,13 +65,6 @@ Stats include: audio_count, audio_samplerate_count,
 mean meadian and certain (10, 25, 75, 90) percentile durations.
 This is helpful in getting a quick glance of the audio files in a folder and 
 helps in decideing the preprocessing configurations.
-
-For development, there is a sampler which could be used to generate small corpuses for testing of each task
-```
-python -m heareval.tasks.sampler <taskname>
-```
-Supported task name are speech_commands, nsynth_pitch and dcase2016_task2
-Sampled small version of the tasks can be found here: [Downsampled HEAR Open Tasks](https://github.com/turian/hear2021-open-tasks-downsampled)
 
 ### Computing embeddings
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ Options:
 
   --sample-rate INTEGER  Perform resampling only to this sample rate. By
                          default we resample to 16000, 22050, 44100, 48000.
+  
+  --small BOOL If True, the task will run on a small [Version](https://github.com/turian/hear2021-open-tasks-downsampled) of the data
 ```
 
 Additionally, to check the stats of an audio directory:

--- a/README.md
+++ b/README.md
@@ -48,8 +48,10 @@ Options:
   --sample-rate INTEGER  Perform resampling only to this sample rate. By
                          default we resample to 16000, 22050, 44100, 48000.
   
-  --small BOOL If True, the task will run on a small [Version](https://github.com/turian/hear2021-open-tasks-downsampled) of the data
+  --small       BOOL     If True, the task will run on a small-version of the 
+                         data.
 ```
+[Link to small version of data](https://github.com/turian/hear2021-open-tasks-downsampled)
 
 Additionally, to check the stats of an audio directory:
 ```

--- a/heareval/tasks/dcase2016_task2.py
+++ b/heareval/tasks/dcase2016_task2.py
@@ -88,7 +88,9 @@ class ExtractMetadata(pipeline.ExtractMetadata):
                 .replace("annotation", "sound")
                 .replace(".txt", ".wav")
             )
-            assert os.path.exists(sound_file)
+            # Remove the assert statement as this file might not exist.
+            # This is anyways ensured in the Base ExtractMetadata task.
+            # assert os.path.exists(sound_file)
             metadata = metadata.assign(
                 relpath=sound_file,
                 slug=lambda df: df.relpath.apply(self.slugify_file_name),
@@ -103,7 +105,9 @@ class ExtractMetadata(pipeline.ExtractMetadata):
         return pd.concat(metadatas)
 
 
-def main(num_workers: int, sample_rates: List[int]):
+def main(num_workers: int, sample_rates: List[int], small: bool = False):
+    if small:
+        pipeline.get_small_config(config)
 
     # Build the dataset pipeline with the custom metadata configuration task
     download_tasks = pipeline.get_download_and_extract_tasks(config)

--- a/heareval/tasks/dcase2016_task2.py
+++ b/heareval/tasks/dcase2016_task2.py
@@ -49,12 +49,12 @@ config = {
             {
                 "name": "train",
                 "url": "https://github.com/turian/hear2021-open-tasks-downsampled/raw/main/dcase2016_task2_train_dev-small.zip",  # noqa: E501
-                "md5": "3adca7e1860aedf7d1b0c06358f1b867",
+                "md5": "aa9b43c40e9d496163caab83becf972e",
             },
             {
                 "name": "test",
                 "url": "https://github.com/turian/hear2021-open-tasks-downsampled/raw/main/dcase2016_task2_test_public-small.zip",  # noqa: E501
-                "md5": "73446e2156cb5f1d44a1de1e70e536a5",
+                "md5": "14539d85dec03cb7ac75eb62dd1dd21e",
             },
         ],
         "version": "hear2021-small",

--- a/heareval/tasks/dcase2016_task2.py
+++ b/heareval/tasks/dcase2016_task2.py
@@ -131,7 +131,7 @@ def main(
     small: bool = False,
 ):
     if small:
-        config.update(config["small"])
+        config.update(dict(config["small"])) # type: ignore
     config.update({"luigi_dir": luigi_dir})
 
     # Build the dataset pipeline with the custom metadata configuration task

--- a/heareval/tasks/dcase2016_task2.py
+++ b/heareval/tasks/dcase2016_task2.py
@@ -9,7 +9,6 @@ We also allow training data outside this task.
 """
 
 import logging
-import os
 from pathlib import Path
 from typing import List
 

--- a/heareval/tasks/dcase2016_task2.py
+++ b/heareval/tasks/dcase2016_task2.py
@@ -16,7 +16,6 @@ import luigi
 import pandas as pd
 
 import heareval.tasks.pipeline as pipeline
-import heareval.tasks.util.luigi as luigi_utils
 
 logger = logging.getLogger("luigi-interface")
 
@@ -43,7 +42,7 @@ config = {
     "splits": [
         {"name": "train", "max_files": 10},
         {"name": "test", "max_files": 10},
-        {"name": "valid", "max_files": 10},
+        {"name": "valid", "max_files": 2},
     ],
     "small": {
         "download_urls": [
@@ -58,7 +57,6 @@ config = {
                 "md5": "73446e2156cb5f1d44a1de1e70e536a5",
             },
         ],
-        "small_flag": True,
         "version": "hear2021-small",
         "splits": [
             {"name": "train", "max_files": 100},
@@ -131,7 +129,7 @@ def main(
     small: bool = False,
 ):
     if small:
-        config.update(dict(config["small"])) # type: ignore
+        config.update(dict(config["small"]))  # type: ignore
     config.update({"luigi_dir": luigi_dir})
 
     # Build the dataset pipeline with the custom metadata configuration task

--- a/heareval/tasks/nsynth_pitch.py
+++ b/heareval/tasks/nsynth_pitch.py
@@ -134,7 +134,7 @@ def main(
     small: bool = False,
 ):
     if small:
-        config.update(config["small"])
+        config.update(dict(config["small"])) # type: ignore
     config.update({"luigi_dir": luigi_dir})
 
     # Build the dataset pipeline with the custom metadata configuration task

--- a/heareval/tasks/nsynth_pitch.py
+++ b/heareval/tasks/nsynth_pitch.py
@@ -100,7 +100,9 @@ class ExtractMetadata(pipeline.ExtractMetadata):
         return metadata
 
 
-def main(num_workers: int, sample_rates: List[int]):
+def main(num_workers: int, sample_rates: List[int], small: bool = False):
+    if small:
+        pipeline.get_small_config(config)
 
     # Build the dataset pipeline with the custom metadata configuration task
     download_tasks = pipeline.get_download_and_extract_tasks(config)

--- a/heareval/tasks/nsynth_pitch.py
+++ b/heareval/tasks/nsynth_pitch.py
@@ -97,7 +97,7 @@ class ExtractMetadata(pipeline.ExtractMetadata):
             )
         )
 
-        return metadata[["relpath", "slug", "subsample_key", "split", "label"]]
+        return metadata
 
 
 def main(num_workers: int, sample_rates: List[int]):

--- a/heareval/tasks/nsynth_pitch.py
+++ b/heareval/tasks/nsynth_pitch.py
@@ -64,7 +64,6 @@ config = {
                 "md5": "da3a6b20b5b00a60037abc9355add3f9",
             },
         ],
-        "small_flag": True,
         "version": "v2.2.3-small",
         "splits": [
             {"name": "train", "max_files": 100},
@@ -134,7 +133,7 @@ def main(
     small: bool = False,
 ):
     if small:
-        config.update(dict(config["small"])) # type: ignore
+        config.update(dict(config["small"]))  # type: ignore
     config.update({"luigi_dir": luigi_dir})
 
     # Build the dataset pipeline with the custom metadata configuration task

--- a/heareval/tasks/nsynth_pitch.py
+++ b/heareval/tasks/nsynth_pitch.py
@@ -51,17 +51,17 @@ config = {
             {
                 "name": "train",
                 "url": "https://github.com/turian/hear2021-open-tasks-downsampled/raw/main/nsynth-train-small.zip",  # noqa: E501
-                "md5": "1222321b8694e64706370175bb19f7bc",
+                "md5": "c17070e4798655d8bea1231506479ba8",
             },
             {
                 "name": "valid",
                 "url": "https://github.com/turian/hear2021-open-tasks-downsampled/raw/main/nsynth-valid-small.zip",  # noqa: E501
-                "md5": "17653ba28da0eb6cb96f70f3600c08f3",
+                "md5": "e36722262497977f6b945bb06ab0969d",
             },
             {
                 "name": "test",
                 "url": "https://github.com/turian/hear2021-open-tasks-downsampled/raw/main/nsynth-test-small.zip",  # noqa: E501
-                "md5": "da3a6b20b5b00a60037abc9355add3f9",
+                "md5": "9a98e869ed4add8ba9ebb0d7c22becca",
             },
         ],
         "version": "v2.2.3-small",

--- a/heareval/tasks/pipeline.py
+++ b/heareval/tasks/pipeline.py
@@ -24,6 +24,10 @@ from heareval.tasks.util.luigi import (
     subsample_metadata,
 )
 
+OPEN_SMALL_DATASET_ROOT = (
+    "https://github.com/turian/hear2021-open-tasks-downsampled/raw/main/"
+)
+
 
 class DownloadCorpus(WorkTask):
     """
@@ -84,6 +88,27 @@ class ExtractArchive(WorkTask):
         )
 
         self.mark_complete()
+
+
+def get_small_config(config: Dict):
+    """
+    Modifies the config for a small version of the dataset
+    1. Changes the download urls for each data to the small url
+    2. Changes the version of the task to add a -small tag
+    """
+    config["download_urls"] = [
+        {
+            "name": urlobj["name"],
+            "url": "{root}{zip_download_name}-small.zip".format(
+                root=OPEN_SMALL_DATASET_ROOT,
+                zip_download_name=Path(urlparse(urlobj["url"]).path).name.split(".")[0],
+            ),
+            #Set the md5 to zero so that the md5 is not checked
+            "md5": 0,
+        }
+        for urlobj in config["download_urls"]
+    ]
+    config["version"] = "{version}-small".format(version=config["version"])
 
 
 def get_download_and_extract_tasks(config: Dict):

--- a/heareval/tasks/pipeline.py
+++ b/heareval/tasks/pipeline.py
@@ -24,10 +24,6 @@ from heareval.tasks.util.luigi import (
     subsample_metadata,
 )
 
-OPEN_SMALL_DATASET_ROOT = (
-    "https://github.com/turian/hear2021-open-tasks-downsampled/raw/main/"
-)
-
 
 class DownloadCorpus(WorkTask):
     """
@@ -88,27 +84,6 @@ class ExtractArchive(WorkTask):
         )
 
         self.mark_complete()
-
-
-def get_small_config(config: Dict):
-    """
-    Modifies the config for a small version of the dataset
-    1. Changes the download urls for each data to the small url
-    2. Changes the version of the task to add a -small tag
-    """
-    config["download_urls"] = [
-        {
-            "name": urlobj["name"],
-            "url": "{root}{zip_download_name}-small.zip".format(
-                root=OPEN_SMALL_DATASET_ROOT,
-                zip_download_name=Path(urlparse(urlobj["url"]).path).name.split(".")[0],
-            ),
-            # Set the md5 to empty string so that the md5 is not checked
-            "md5": "",
-        }
-        for urlobj in config["download_urls"]
-    ]
-    config["version"] = "{version}-small".format(version=config["version"])
 
 
 def get_download_and_extract_tasks(config: Dict):
@@ -290,13 +265,17 @@ class ExtractMetadata(WorkTask):
         exists = process_metadata["relpath"].apply(
             lambda relpath: Path(relpath).exists()
         )
+
         if sum(exists) < len(process_metadata):
-            print(
-                "All Files in metadata doesnot exist in the dataset. "
-                f"Removing {len(process_metadata) - sum(exists)} entries in the "
-                "metadata"
-            )
-            process_metadata = process_metadata.loc[exists]
+            if "small" in self.data_config:
+                print(
+                    "All Files in metadata doesnot exist in the dataset. "
+                    f"Removing {len(process_metadata) - sum(exists)} entries in the "
+                    "metadata"
+                )
+                process_metadata = process_metadata.loc[exists]
+            else:
+                raise FileNotFoundError("All files in metadata are not found")
 
         process_metadata.to_csv(
             self.workdir.joinpath(self.outfile),

--- a/heareval/tasks/pipeline.py
+++ b/heareval/tasks/pipeline.py
@@ -260,7 +260,7 @@ class ExtractMetadata(WorkTask):
         # Depending on whether valid and test are already present, the percentage can
         # either be the predefined percentage or 0
         valid_perc = VALIDATION_PERCENTAGE if "valid" in splits_to_sample else 0
-        test_perc = VALIDATION_PERCENTAGE if "test" in splits_to_sample else 0
+        test_perc = TESTING_PERCENTAGE if "test" in splits_to_sample else 0
 
         metadata[metadata["split"] == "train"] = metadata[
             metadata["split"] == "train"

--- a/heareval/tasks/pipeline.py
+++ b/heareval/tasks/pipeline.py
@@ -103,8 +103,8 @@ def get_small_config(config: Dict):
                 root=OPEN_SMALL_DATASET_ROOT,
                 zip_download_name=Path(urlparse(urlobj["url"]).path).name.split(".")[0],
             ),
-            #Set the md5 to zero so that the md5 is not checked
-            "md5": 0,
+            # Set the md5 to empty string so that the md5 is not checked
+            "md5": "",
         }
         for urlobj in config["download_urls"]
     ]

--- a/heareval/tasks/pipeline.py
+++ b/heareval/tasks/pipeline.py
@@ -286,6 +286,18 @@ class ExtractMetadata(WorkTask):
                 "%s embedding_type unknown" % self.data_config["embedding_type"]
             )
 
+        # Remove files from the process metadata which donot exist in the dataset.
+        exists = process_metadata["relpath"].apply(
+            lambda relpath: Path(relpath).exists()
+        )
+        if sum(exists) < len(process_metadata):
+            print(
+                "All Files in metadata doesnot exist in the dataset. "
+                f"Removing {len(process_metadata) - sum(exists)} entries in the "
+                "metadata"
+            )
+            process_metadata = process_metadata.loc[exists]
+
         process_metadata.to_csv(
             self.workdir.joinpath(self.outfile),
             index=False,

--- a/heareval/tasks/pipeline.py
+++ b/heareval/tasks/pipeline.py
@@ -193,15 +193,15 @@ class ExtractMetadata(WorkTask):
         """
         Gets the subsample key.
         Subsample key is a unique hash at a audio file level used for subsampling.
-        This is a hash of the relpath. This is not recommended to be
+        This is a hash of the slug. This is not recommended to be
         overridden.
 
         The data is first split by the split key and the subsample key is
         used to ensure stable sampling for groups which are incompletely
         sampled(the last group to be part of the subsample output)
         """
-        assert "relpath" in df, "relpath column not found in the dataframe"
-        return df["relpath"].apply(str).apply(filename_to_int_hash)
+        assert "slug" in df, "relpath column not found in the dataframe"
+        return df["slug"].apply(str).apply(filename_to_int_hash)
 
     def get_process_metadata(self) -> pd.DataFrame:
         """

--- a/heareval/tasks/pipeline.py
+++ b/heareval/tasks/pipeline.py
@@ -727,6 +727,7 @@ class FinalizeCorpus(WorkTask):
 
     sample_rates = luigi.ListParameter()
     metadata = luigi.TaskParameter()
+    tasks_dir = luigi.Parameter()
 
     def requires(self):
         # Will copy the resampled data and the traintestmeta and the vocabmeta
@@ -748,7 +749,7 @@ class FinalizeCorpus(WorkTask):
     # the finalized top-level task directory
     @property
     def workdir(self):
-        return Path("tasks").joinpath(self.versioned_task_name)
+        return Path(self.tasks_dir).joinpath(self.versioned_task_name)
 
     def run(self):
         if self.workdir.exists():

--- a/heareval/tasks/runner.py
+++ b/heareval/tasks/runner.py
@@ -39,16 +39,29 @@ tasks = {
     type=int,
 )
 @click.option(
+    "--luigi-dir",
+    default="_workdir",
+    help="Directory to save all the intermediate tasks",
+    type=str,
+)
+@click.option(
+    "--tasks-dir",
+    default="tasks",
+    help="Directory to save all the intermediate tasks",
+    type=str,
+)
+@click.option(
     "--small",
-    default=False,
-    help="Run Pipeline on a small version of the dataset"
-    "By default this is set to false",
+    is_flag=True,
+    help="Run pipeline on small version of data",
     type=bool,
 )
 def run(
     task: str,
     num_workers: Optional[int] = None,
     sample_rate: Optional[int] = None,
+    luigi_dir: Optional[str] = "_workdir",
+    tasks_dir: Optional[str] = "tasks",
     small: bool = False,
 ):
 
@@ -62,7 +75,11 @@ def run(
         sample_rates = [sample_rate]
 
     tasks[task].main(  # type: ignore
-        num_workers=num_workers, sample_rates=sample_rates, small=small
+        num_workers=num_workers,
+        sample_rates=sample_rates,
+        luigi_dir=luigi_dir,
+        tasks_dir=tasks_dir,
+        small=small,
     )
 
 

--- a/heareval/tasks/runner.py
+++ b/heareval/tasks/runner.py
@@ -38,8 +38,18 @@ tasks = {
     "By default we resample to 16000, 22050, 44100, 48000.",
     type=int,
 )
+@click.option(
+    "--small",
+    default=False,
+    help="Run Pipeline on a small version of the dataset"
+    "By default this is set to false",
+    type=bool,
+)
 def run(
-    task: str, num_workers: Optional[int] = None, sample_rate: Optional[int] = None
+    task: str,
+    num_workers: Optional[int] = None,
+    sample_rate: Optional[int] = None,
+    small: bool = False,
 ):
 
     if num_workers is None:
@@ -51,7 +61,7 @@ def run(
     else:
         sample_rates = [sample_rate]
 
-    tasks[task].main(num_workers=num_workers, sample_rates=sample_rates)  # type: ignore
+    tasks[task].main(num_workers=num_workers, sample_rates=sample_rates, small=small)  # type: ignore
 
 
 if __name__ == "__main__":

--- a/heareval/tasks/runner.py
+++ b/heareval/tasks/runner.py
@@ -47,7 +47,7 @@ tasks = {
 @click.option(
     "--tasks-dir",
     default="tasks",
-    help="Directory to save all the intermediate tasks",
+    help="Directory to save the final task output",
     type=str,
 )
 @click.option(

--- a/heareval/tasks/runner.py
+++ b/heareval/tasks/runner.py
@@ -61,9 +61,9 @@ def run(
     else:
         sample_rates = [sample_rate]
 
-    tasks[task].main( # type: ignore
+    tasks[task].main(  # type: ignore
         num_workers=num_workers, sample_rates=sample_rates, small=small
-    )  
+    )
 
 
 if __name__ == "__main__":

--- a/heareval/tasks/runner.py
+++ b/heareval/tasks/runner.py
@@ -61,7 +61,9 @@ def run(
     else:
         sample_rates = [sample_rate]
 
-    tasks[task].main(num_workers=num_workers, sample_rates=sample_rates, small=small)  # type: ignore
+    tasks[task].main( # type: ignore
+        num_workers=num_workers, sample_rates=sample_rates, small=small
+    )  
 
 
 if __name__ == "__main__":

--- a/heareval/tasks/sampler.py
+++ b/heareval/tasks/sampler.py
@@ -45,7 +45,7 @@ configs = {
     },
     "dcase2016_task2": {
         "task_config": dcase2016_task2_config,
-        "audio_sample_size": 10,
+        "audio_sample_size": 4,
         # Add any keys in the file format that we compulsorily need to copy
         "necessary_keys": [],
     },

--- a/heareval/tasks/sampler.py
+++ b/heareval/tasks/sampler.py
@@ -105,7 +105,7 @@ class RandomSampleOriginalDataset(luigi_util.WorkTask):
                     lambda path: luigi_util.filename_to_int_hash(str(path))
                 ),
                 # Split key is same as the subsample key in this case
-                split_key=lambda df: df.split_key,
+                split_key=lambda df: df.subsample_key,
             )
             # The above metadata is passed in the subsample metadata and
             # audio_sample_size number of files are selected
@@ -121,7 +121,7 @@ class RandomSampleOriginalDataset(luigi_util.WorkTask):
             # Sample a small subset to copy from all the files
             url_name = Path(urlparse(url_obj["url"]).path).stem
             split = url_obj["name"]
-            copy_from = self.requires()[split].workdir.joinpath(url_name)
+            copy_from = self.requires()[split].workdir.joinpath(split)
             all_files = [file.relative_to(copy_from) for file in copy_from.rglob("*")]
             copy_files = self.sample(all_files)
 
@@ -131,7 +131,7 @@ class RandomSampleOriginalDataset(luigi_util.WorkTask):
                 shutil.rmtree(copy_to)
             for file in tqdm(copy_files):
                 self.safecopy(src=copy_from.joinpath(file), dst=copy_to.joinpath(file))
-            shutil.make_archive(f"{copy_to}-small", "zip", copy_to)
+            shutil.make_archive(copy_to, "zip", copy_to)
 
 
 @click.command()

--- a/heareval/tasks/sampler.py
+++ b/heareval/tasks/sampler.py
@@ -2,9 +2,9 @@
 """
 Runs a sampler to sample the downloaded dataset.
 
-Uses the same download and extract tasks to make sure 
+Uses the same download and extract tasks to make sure
 the same downloaded files can be used for sampling
-Also uses the configs defined in the task files for making 
+Also uses the configs defined in the task files for making
 it simple to scale across multiple dataset
 """
 

--- a/heareval/tasks/sampler.py
+++ b/heareval/tasks/sampler.py
@@ -124,7 +124,7 @@ class RandomSampleOriginalDataset(luigi_util.WorkTask):
                 self.safecopy(
                     src=file, dst=copy_to.joinpath(file.relative_to(copy_from))
                 )
-            shutil.make_archive(copy_to, "zip", copy_to)
+            shutil.make_archive(f"{copy_to}-small", "zip", copy_to)
 
 
 @click.command()

--- a/heareval/tasks/sampler.py
+++ b/heareval/tasks/sampler.py
@@ -44,9 +44,14 @@ configs = {
     "dcase2016_task2": {
         "task_config": dcase2016_task2.config,
         "audio_sample_size": 4,
-        # dev-1-ebr-6-nec-2-poly-0 -> 1 train file in train split
-        # dev-1-ebr-6-nec-4-poly-1 -> 1 train file in valid split
-        "necessary_keys": ["dev_1_ebr_6_nec_2_poly_0.wav", "dev_1_ebr_6_nec_4_poly_1"],
+        # Put two files from the dev and train split so that those splits are
+        # made
+        # dev_1_ebr_6_nec_2_poly_0.wav -> 1 train file in train split
+        # dev_1_ebr_6_nec_3_poly_0.wav -> 1 train file in valid split
+        "necessary_keys": [
+            "dev_1_ebr_6_nec_2_poly_0.wav",
+            "dev_1_ebr_6_nec_3_poly_0.wav",
+        ],
     },
 }
 

--- a/heareval/tasks/sampler.py
+++ b/heareval/tasks/sampler.py
@@ -103,7 +103,7 @@ class RandomSampleOriginalDataset(luigi_util.WorkTask):
         audio_files = luigi_util.subsample_metadata(
             metadata, self.audio_sample_size
         ).audio_path.to_list()
-        
+
         return metadata_files + necessary_files + audio_files
 
     def run(self):

--- a/heareval/tasks/speech_commands.py
+++ b/heareval/tasks/speech_commands.py
@@ -50,13 +50,13 @@ config = {
         "download_urls": [
             {
                 "name": "train",
-                "url": "https://github.com/turian/hear2021-open-tasks-downsampled/raw/main/speech_commands_v0-small.zip",  # noqa: E501
-                "md5": "74d72a260d2fd24fcfd05ed2e2943f52",
+                "url": "https://github.com/turian/hear2021-open-tasks-downsampled/raw/main/speech_commands_v0.02-small.zip",  # noqa: E501
+                "md5": "455123a88b8410d1f955c77ad331524f",
             },
             {
                 "name": "test",
-                "url": "https://github.com/turian/hear2021-open-tasks-downsampled/raw/main/speech_commands_test_set_v0-small.zip",  # noqa: E501
-                "md5": "46716349e9296d3e57c6f6914627003c",
+                "url": "https://github.com/turian/hear2021-open-tasks-downsampled/raw/main/speech_commands_test_set_v0.02-small.zip",  # noqa: E501
+                "md5": "26d08374a7abd13ca2f4a4b8424f41d0",
             },
         ],
         "version": "v0.0.2-small",

--- a/heareval/tasks/speech_commands.py
+++ b/heareval/tasks/speech_commands.py
@@ -236,8 +236,8 @@ def main(
     small: bool = False,
 ):
     if small:
-        config.update(config["small"])
-    config.update(**{"luigi_dir": luigi_dir})
+        config.update(dict(config["small"])) # type: ignore
+    config.update({"luigi_dir": luigi_dir})
 
     # Build the dataset pipeline with the custom metadata configuration task
     download_tasks = pipeline.get_download_and_extract_tasks(config)

--- a/heareval/tasks/speech_commands.py
+++ b/heareval/tasks/speech_commands.py
@@ -207,7 +207,9 @@ class ExtractMetadata(pipeline.ExtractMetadata):
         return process_metadata
 
 
-def main(num_workers: int, sample_rates: List[int]):
+def main(num_workers: int, sample_rates: List[int], small: bool = False):
+    if small:
+        pipeline.get_small_config(config)
 
     download_tasks = pipeline.get_download_and_extract_tasks(config)
 

--- a/heareval/tasks/speech_commands.py
+++ b/heareval/tasks/speech_commands.py
@@ -59,7 +59,6 @@ config = {
                 "md5": "46716349e9296d3e57c6f6914627003c",
             },
         ],
-        "small_flag": True,
         "version": "v0.0.2-small",
         "splits": [
             {"name": "train", "max_files": 100},
@@ -236,7 +235,7 @@ def main(
     small: bool = False,
 ):
     if small:
-        config.update(dict(config["small"])) # type: ignore
+        config.update(dict(config["small"]))  # type: ignore
     config.update({"luigi_dir": luigi_dir})
 
     # Build the dataset pipeline with the custom metadata configuration task

--- a/heareval/tasks/util/luigi.py
+++ b/heareval/tasks/util/luigi.py
@@ -123,9 +123,9 @@ def download_file(url, local_filename, expected_md5):
                 f.write(chunk)
                 pbar.update(chunk_size)
             pbar.close()
-    # If expected_md5 is 0, the check is not done
-    if expected_md5:
-        assert md5sum(local_filename) == expected_md5
+    assert (
+        md5sum(local_filename) == expected_md5
+    ), f"Md5sum for url: {url} is: {md5sum(local_filename)}"
     return local_filename
 
 

--- a/heareval/tasks/util/luigi.py
+++ b/heareval/tasks/util/luigi.py
@@ -121,7 +121,9 @@ def download_file(url, local_filename, expected_md5):
                 f.write(chunk)
                 pbar.update(chunk_size)
             pbar.close()
-    assert md5sum(local_filename) == expected_md5
+    # If expected_md5 is 0, the check is not done
+    if expected_md5:
+        assert md5sum(local_filename) == expected_md5
     return local_filename
 
 

--- a/heareval/tasks/util/luigi.py
+++ b/heareval/tasks/util/luigi.py
@@ -64,7 +64,9 @@ class WorkTask(luigi.Task):
     @property
     def task_subdir(self):
         """Task specific subdirectory"""
-        return Path("_workdir").joinpath(str(self.versioned_task_name))
+        return Path(self.data_config.get("luigi_dir", "_workdir")).joinpath(
+            str(self.versioned_task_name)
+        )
 
     @property
     def versioned_task_name(self):


### PR DESCRIPTION
Adds
- download the small version of the data from [HEAR OPEN TASK](https://github.com/turian/hear2021-open-tasks-downsampled)
- add `-small` tag to the version of the task and corresponding change in the runner for running the small task.
- add option to change the base directory for the task and the luigi intermediate outputs.
- fixes the subsampling to be deterministic by changing the subsample key to be hash of the slug.
- cleanup the sampler and make it deterministic as well