### PR TITLE
Max task duration

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,8 @@ Each pipeline will download and preprocess each dataset according
 to the following DAG:
 * DownloadCorpus
 * ExtractArchive
-* ExtractMetadata
+* ExtractMetadata: Create splits over the entire corpus and find
+the label metadata for them.
 * SubsampleSplit (subsample each split) => MonoWavTrimCorpus => SplitData (symlinks)
 * SplitData => {SplitMetadata, ResampleSubcorpus}
 * SplitMetadata => MetadataVocabulary

--- a/README.md
+++ b/README.md
@@ -121,6 +121,15 @@ python3 -m heareval.tasks.runner all
 You can also just run individual tasks:
 python3 -m heareval.tasks.runner [speech_commands|nsynth_pitch|dcase2016_task2]
 
+Each pipeline will download and preprocess each dataset according
+to the following DAG:
+* download and extract datafiles
+* ExtractMetadata
+* SubsampleSplit (subsample each split) => MonoWavTrimCorpus => SplitData (symlinks)
+* SplitData => {SplitMetadata, ResampleSubcorpus}
+* SplitMetadata => MetadataVocabulary
+* FinalizeCorpus
+
 These commands will download and preprocess the entire dataset. An
 intermediary directory defined by the option `luigi-dir`(default
 `_workdir`) will be created, and then a final directory defined by
@@ -183,6 +192,7 @@ deterministically with the following command:
 python3 -m heareval.tasks.sampler <taskname>
 ```
 
+[rewrite]
 **_NOTE_** : Each task config has `dataset_fraction`. The data in
 each split is subsampled by this fraction in the final output. This
 is not to be confused with the `--small` flag which is used to run

--- a/README.md
+++ b/README.md
@@ -132,6 +132,12 @@ the label metadata for them.
 * SplitMetadata => MetadataVocabulary
 * FinalizeCorpus
 
+In terms of sampling:
+* We create a 60/20/20 split if train/valid/test does not exist.
+* We cap each split at 3/1/1/ hours of audio.
+* If further small sampling happens, that chooses a particular
+number of audio samples per task.
+
 These commands will download and preprocess the entire dataset. An
 intermediary directory defined by the option `luigi-dir`(default
 `_workdir`) will be created, and then a final directory defined by

--- a/README.md
+++ b/README.md
@@ -123,7 +123,8 @@ python3 -m heareval.tasks.runner [speech_commands|nsynth_pitch|dcase2016_task2]
 
 Each pipeline will download and preprocess each dataset according
 to the following DAG:
-* download and extract datafiles
+* DownloadCorpus
+* ExtractArchive
 * ExtractMetadata
 * SubsampleSplit (subsample each split) => MonoWavTrimCorpus => SplitData (symlinks)
 * SplitData => {SplitMetadata, ResampleSubcorpus}

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ the label metadata for them.
 
 In terms of sampling:
 * We create a 60/20/20 split if train/valid/test does not exist.
-* We cap each split at 3/1/1/ hours of audio.
+* We cap each split at 3/1/1/ hours of audio, defined as
 * If further small sampling happens, that chooses a particular
 number of audio samples per task.
 
@@ -200,14 +200,8 @@ deterministically with the following command:
 python3 -m heareval.tasks.sampler <taskname>
 ```
 
-[rewrite]
-**_NOTE_** : Each task config has `dataset_fraction`. The data in
-each split is subsampled by this fraction in the final output. This
-is not to be confused with the `--small` flag which is used to run
-the task on a small version of the dataset for development. Also
-the small version in the config has its own `dataset_fraction` which
-can be used to subsample the small dataset when the small flag is
-passed.
+**_NOTE_** : The `--small` flag which is used to run the task on a
+small version of the dataset for development.
 
 ### End to end testing
 

--- a/heareval/embeddings/task_embeddings.py
+++ b/heareval/embeddings/task_embeddings.py
@@ -38,6 +38,8 @@ from intervaltree import IntervalTree
 from torch.utils.data import DataLoader, Dataset
 from tqdm.auto import tqdm
 
+from heareval.tasks.pipeline import SPLITS
+
 TORCH = "torch"
 TENSORFLOW = "tf"
 
@@ -372,7 +374,7 @@ def task_embeddings(embedding: Embedding, task_path: Path, embeddings_dir: Path)
     shutil.copy(metadata_path, embed_task_dir)
     shutil.copy(label_vocab_path, embed_task_dir)
 
-    for split in metadata["splits"]:
+    for split in SPLITS:
         print(f"Getting embeddings for split: {split}")
 
         split_path = task_path.joinpath(f"{split}.json")

--- a/heareval/tasks/dcase2016_task2.py
+++ b/heareval/tasks/dcase2016_task2.py
@@ -37,7 +37,6 @@ config = {
         },
     ],
     "sample_duration": 120.0,
-    "splits": ["train", "test", "valid"],
     "small": {
         "download_urls": [
             {

--- a/heareval/tasks/dcase2016_task2.py
+++ b/heareval/tasks/dcase2016_task2.py
@@ -37,7 +37,6 @@ config = {
         },
     ],
     "sample_duration": 120.0,
-    "dataset_fraction": None,
     "splits": ["train", "test", "valid"],
     "small": {
         "download_urls": [
@@ -53,7 +52,6 @@ config = {
             },
         ],
         "version": "hear2021-small",
-        "dataset_fraction": None,
     },
     # DCASE2016 task 2 used the segment-based total error rate as
     # their main score and then the onset only event based F1 as

--- a/heareval/tasks/dcase2016_task2.py
+++ b/heareval/tasks/dcase2016_task2.py
@@ -19,7 +19,7 @@ import heareval.tasks.pipeline as pipeline
 
 logger = logging.getLogger("luigi-interface")
 
-config = {
+task_config = {
     "task_name": "dcase2016_task2",
     "version": "hear2021",
     "embedding_type": "event",
@@ -121,19 +121,19 @@ def main(
     small: bool = False,
 ):
     if small:
-        config.update(dict(config["small"]))  # type: ignore
-    config.update({"tmp_dir": tmp_dir})
+        task_config.update(dict(task_config["small"]))  # type: ignore
+    task_config.update({"tmp_dir": tmp_dir})
 
     # Build the dataset pipeline with the custom metadata configuration task
-    download_tasks = pipeline.get_download_and_extract_tasks(config)
+    download_tasks = pipeline.get_download_and_extract_tasks(task_config)
 
     configure_metadata = ExtractMetadata(
-        outfile="process_metadata.csv", data_config=config, **download_tasks
+        outfile="process_metadata.csv", task_config=task_config, **download_tasks
     )
     final_task = pipeline.FinalizeCorpus(
         sample_rates=sample_rates,
         tasks_dir=tasks_dir,
         metadata=configure_metadata,
-        data_config=config,
+        task_config=task_config,
     )
     return final_task

--- a/heareval/tasks/dcase2016_task2.py
+++ b/heareval/tasks/dcase2016_task2.py
@@ -116,13 +116,13 @@ class ExtractMetadata(pipeline.ExtractMetadata):
 
 def main(
     sample_rates: List[int],
-    work_dir: str,
+    tmp_dir: str,
     tasks_dir: str,
     small: bool = False,
 ):
     if small:
         config.update(dict(config["small"]))  # type: ignore
-    config.update({"work_dir": work_dir})
+    config.update({"tmp_dir": tmp_dir})
 
     # Build the dataset pipeline with the custom metadata configuration task
     download_tasks = pipeline.get_download_and_extract_tasks(config)

--- a/heareval/tasks/nsynth_pitch.py
+++ b/heareval/tasks/nsynth_pitch.py
@@ -39,7 +39,6 @@ config = {
         },
     ],
     "sample_duration": 4.0,
-    "dataset_fraction": None,
     "splits": ["train", "test", "valid"],
     "pitch_range_min": 21,
     "pitch_range_max": 108,
@@ -62,7 +61,6 @@ config = {
             },
         ],
         "version": "v2.2.3-small",
-        "dataset_fraction": None,
     },
     "evaluation": ["pitch_acc", "chroma_acc"],
 }

--- a/heareval/tasks/nsynth_pitch.py
+++ b/heareval/tasks/nsynth_pitch.py
@@ -118,13 +118,13 @@ class ExtractMetadata(pipeline.ExtractMetadata):
 
 def main(
     sample_rates: List[int],
-    work_dir: str,
+    tmp_dir: str,
     tasks_dir: str,
     small: bool = False,
 ):
     if small:
         config.update(dict(config["small"]))  # type: ignore
-    config.update({"work_dir": work_dir})
+    config.update({"tmp_dir": tmp_dir})
 
     # Build the dataset pipeline with the custom metadata configuration task
     download_tasks = pipeline.get_download_and_extract_tasks(config)

--- a/heareval/tasks/nsynth_pitch.py
+++ b/heareval/tasks/nsynth_pitch.py
@@ -16,7 +16,7 @@ import heareval.tasks.pipeline as pipeline
 logger = logging.getLogger("luigi-interface")
 
 
-config = {
+task_config = {
     "task_name": "nsynth_pitch",
     "version": "v2.2.3",
     "embedding_type": "scene",
@@ -97,7 +97,7 @@ class ExtractMetadata(pipeline.ExtractMetadata):
             # Filter out pitches that are not within the range
             metadata.loc[
                 metadata["pitch"].between(
-                    config["pitch_range_min"], config["pitch_range_max"]
+                    task_config["pitch_range_min"], task_config["pitch_range_max"]
                 )
                 # Assign metadata columns
             ].assign(
@@ -123,19 +123,19 @@ def main(
     small: bool = False,
 ):
     if small:
-        config.update(dict(config["small"]))  # type: ignore
-    config.update({"tmp_dir": tmp_dir})
+        task_config.update(dict(task_config["small"]))  # type: ignore
+    task_config.update({"tmp_dir": tmp_dir})
 
     # Build the dataset pipeline with the custom metadata configuration task
-    download_tasks = pipeline.get_download_and_extract_tasks(config)
+    download_tasks = pipeline.get_download_and_extract_tasks(task_config)
 
     configure_metadata = ExtractMetadata(
-        outfile="process_metadata.csv", data_config=config, **download_tasks
+        outfile="process_metadata.csv", task_config=task_config, **download_tasks
     )
     final_task = pipeline.FinalizeCorpus(
         sample_rates=sample_rates,
         tasks_dir=tasks_dir,
         metadata=configure_metadata,
-        data_config=config,
+        task_config=task_config,
     )
     return final_task

--- a/heareval/tasks/nsynth_pitch.py
+++ b/heareval/tasks/nsynth_pitch.py
@@ -39,7 +39,6 @@ config = {
         },
     ],
     "sample_duration": 4.0,
-    "splits": ["train", "test", "valid"],
     "pitch_range_min": 21,
     "pitch_range_max": 108,
     "small": {

--- a/heareval/tasks/pipeline.py
+++ b/heareval/tasks/pipeline.py
@@ -25,6 +25,7 @@ from heareval.tasks.util.luigi import (
     which_set,
 )
 
+SPLITS = ["train", "valid", "test"]
 # This percentage should not be changed as this decides
 # the data in the split and hence is not a part of the data config
 VALIDATION_PERCENTAGE = 20
@@ -252,13 +253,6 @@ class ExtractMetadata(WorkTask):
         are not found
         This uses the split key to do the split with the which set function.
         """
-        splits_present = metadata["split"].unique()
-        # The metadata should at least have the train split
-        # test and valid if not found in the metadata can be sampled
-        # from the train
-        assert "train" in splits_present, "Train split not found in metadata"
-        print(f"Splits getting sampled with the split key are: {splits_to_sample}")
-
         metadata[metadata["split"] == "train"] = metadata[
             metadata["split"] == "train"
         ].assign(

--- a/heareval/tasks/pipeline.py
+++ b/heareval/tasks/pipeline.py
@@ -270,13 +270,14 @@ class ExtractMetadata(WorkTask):
         assert "train" in splits_present, "Train split not found in metadata"
         splits_to_sample = set(SPLITS).difference(splits_present)
         print(
-            f"Splits not already present in the dataset, now sampled with split key are: {splits_to_sample}"
+            "Splits not already present in the dataset, "
+            + f"now sampled with split key are: {splits_to_sample}"
         )
 
         # Depending on whether valid and test are already present, the percentage can
         # either be the predefined percentage or 0
         valid_perc = VALIDATION_PERCENTAGE if "valid" in splits_to_sample else 0
-        test_perc = TESTING_PERCENTAGE if "test" in splits_to_sample else 0
+        test_perc = TEST_PERCENTAGE if "test" in splits_to_sample else 0
 
         metadata[metadata["split"] == "train"] = metadata[
             metadata["split"] == "train"

--- a/heareval/tasks/pipeline.py
+++ b/heareval/tasks/pipeline.py
@@ -29,7 +29,7 @@ SPLITS = ["train", "valid", "test"]
 # This percentage should not be changed as this decides
 # the data in the split and hence is not a part of the data config
 VALIDATION_PERCENTAGE = 20
-TESTING_PERCENTAGE = 20
+TEST_PERCENTAGE = 20
 
 # We want no more than 5 hours of audio per task.
 MAX_TASK_DURATION_BY_SPLIT = {

--- a/heareval/tasks/pipeline.py
+++ b/heareval/tasks/pipeline.py
@@ -466,7 +466,7 @@ class SubsampleSplits(WorkTask):
                 split=split,
                 task_config=self.task_config,
             )
-            for split in self.task_config["splits"]
+            for split in SPLITS
         }
         return subsample_splits
 
@@ -750,7 +750,7 @@ class ResampleSubcorpuses(WorkTask):
                 task_config=self.task_config,
             )
             for sr in self.sample_rates
-            for split in self.task_config["splits"]
+            for split in SPLITS
         ]
         return resample_splits
 

--- a/heareval/tasks/pipeline.py
+++ b/heareval/tasks/pipeline.py
@@ -417,7 +417,7 @@ class SubsampleSplit(WorkTask):
         num_files = len(metadata)
         # This might round badly for small corpora with long audio :\
         # TODO: Issue to check for this
-        sample_duration = self.data_config["sample_duration"]
+        sample_duration = self.task_config["sample_duration"]
         max_files = int(MAX_TASK_DURATION_BY_SPLIT[self.split] / sample_duration)
         if num_files > max_files:
             print(

--- a/heareval/tasks/pipeline.py
+++ b/heareval/tasks/pipeline.py
@@ -107,7 +107,7 @@ def get_download_and_extract_tasks(task_config: Dict):
     """
 
     tasks = {}
-    for urlobj in config["download_urls"]:
+    for urlobj in task_config["download_urls"]:
         name, url, md5 = urlobj["name"], urlobj["url"], urlobj["md5"]
         filename = os.path.basename(urlparse(url).path)
         task = ExtractArchive(

--- a/heareval/tasks/runner.py
+++ b/heareval/tasks/runner.py
@@ -41,7 +41,7 @@ tasks = {
     type=int,
 )
 @click.option(
-    "--tmp-dir",
+    "--tmp_dir",
     default="_workdir",
     help="Temporary directory to save all the "
     + "intermediate tasks (will not be deleted afterwords)",

--- a/heareval/tasks/runner.py
+++ b/heareval/tasks/runner.py
@@ -41,7 +41,7 @@ tasks = {
     type=int,
 )
 @click.option(
-    "--tmp_dir",
+    "--tmp-dir",
     default="_workdir",
     help="Temporary directory to save all the "
     + "intermediate tasks (will not be deleted afterwords)",

--- a/heareval/tasks/sampler.py
+++ b/heareval/tasks/sampler.py
@@ -36,17 +36,17 @@ AUDIOFORMATS = [".mp3", ".wav", ".ogg"]
 
 configs = {
     "nsynth_pitch": {
-        "task_config": nsynth_pitch.config,
+        "task_config": nsynth_pitch.task_config,
         "audio_sample_size": 100,
         "necessary_keys": [],
     },
     "speech_commands": {
-        "task_config": speech_commands.config,
+        "task_config": speech_commands.task_config,
         "audio_sample_size": 100,
         "necessary_keys": [],
     },
     "dcase2016_task2": {
-        "task_config": dcase2016_task2.config,
+        "task_config": dcase2016_task2.task_config,
         "audio_sample_size": 4,
         # Put two files from the dev and train split so that those splits are
         # made
@@ -65,7 +65,7 @@ class RandomSampleOriginalDataset(luigi_util.WorkTask):
     audio_sample_size = luigi.Parameter()
 
     def requires(self):
-        return pipeline.get_download_and_extract_tasks(self.data_config)
+        return pipeline.get_download_and_extract_tasks(self.task_config)
 
     @staticmethod
     def safecopy(dst, src):
@@ -121,7 +121,7 @@ class RandomSampleOriginalDataset(luigi_util.WorkTask):
         return metadata_files + necessary_files + sampled_audio_files
 
     def run(self):
-        for url_obj in self.data_config["small"]["download_urls"]:
+        for url_obj in self.task_config["small"]["download_urls"]:
             # Sample a small subset to copy from all the files
             url_name = Path(urlparse(url_obj["url"]).path).stem
             split = url_obj["name"]
@@ -153,7 +153,7 @@ def main(task: str, num_workers: Optional[int] = None):
     logger.info(f"Using {num_workers} workers")
     config = configs[task]
     sampler = RandomSampleOriginalDataset(
-        data_config=config["task_config"],
+        task_config=config["task_config"],
         audio_sample_size=config["audio_sample_size"],
         necessary_keys=config["necessary_keys"],
     )

--- a/heareval/tasks/sampler.py
+++ b/heareval/tasks/sampler.py
@@ -2,6 +2,10 @@
 """
 Runs a sampler to sample the downloaded dataset.
 
+It resamples each task to have audio_sample_size samples.
+TODO: Consider changing this to a certain number of seconds
+(max_task_duration in the luigi pipeline).
+
 Uses the same download and extract tasks to make sure
 the same downloaded files can be used for sampling
 Also uses the configs defined in the task files for making

--- a/heareval/tasks/speech_commands.py
+++ b/heareval/tasks/speech_commands.py
@@ -221,13 +221,13 @@ class ExtractMetadata(pipeline.ExtractMetadata):
 
 def main(
     sample_rates: List[int],
-    work_dir: str,
+    tmp_dir: str,
     tasks_dir: str,
     small: bool = False,
 ):
     if small:
         config.update(dict(config["small"]))  # type: ignore
-    config.update({"work_dir": work_dir})
+    config.update({"tmp_dir": tmp_dir})
 
     # Build the dataset pipeline with the custom metadata configuration task
     download_tasks = pipeline.get_download_and_extract_tasks(config)

--- a/heareval/tasks/speech_commands.py
+++ b/heareval/tasks/speech_commands.py
@@ -40,7 +40,6 @@ config = {
         },
     ],
     "sample_duration": 1.0,
-    "dataset_fraction": None,
     "splits": ["train", "test", "valid"],
     "small": {
         "download_urls": [
@@ -56,7 +55,6 @@ config = {
             },
         ],
         "version": "v0.0.2-small",
-        "dataset_fraction": None,
     },
     "evaluation": ["top1_acc"],
 }
@@ -139,7 +137,7 @@ class ExtractMetadata(pipeline.ExtractMetadata):
     def slugify_file_name(relative_path: str) -> str:
         """
         For speech command each speaker might have given samples for
-        different labels. In this case, just sluggifying the file name
+        different metadata. In this case, just sluggifying the file name
         without the label would cause duplicates
         """
         # Get the foldername which is the label and the filename

--- a/heareval/tasks/speech_commands.py
+++ b/heareval/tasks/speech_commands.py
@@ -40,7 +40,6 @@ config = {
         },
     ],
     "sample_duration": 1.0,
-    "splits": ["train", "test", "valid"],
     "small": {
         "download_urls": [
             {

--- a/heareval/tasks/speech_commands.py
+++ b/heareval/tasks/speech_commands.py
@@ -22,7 +22,7 @@ BACKGROUND_NOISE = "_background_noise_"
 UNKNOWN = "_unknown_"
 SILENCE = "_silence_"
 
-config = {
+task_config = {
     "task_name": "speech_commands",
     "version": "v0.0.2",
     "embedding_type": "scene",
@@ -226,26 +226,26 @@ def main(
     small: bool = False,
 ):
     if small:
-        config.update(dict(config["small"]))  # type: ignore
-    config.update({"tmp_dir": tmp_dir})
+        task_config.update(dict(task_config["small"]))  # type: ignore
+    task_config.update({"tmp_dir": tmp_dir})
 
     # Build the dataset pipeline with the custom metadata configuration task
-    download_tasks = pipeline.get_download_and_extract_tasks(config)
+    download_tasks = pipeline.get_download_and_extract_tasks(task_config)
 
     generate = GenerateTrainDataset(
-        train_data=download_tasks["train"], data_config=config
+        train_data=download_tasks["train"], task_config=task_config
     )
     configure_metadata = ExtractMetadata(
         train=generate,
         test=download_tasks["test"],
         outfile="process_metadata.csv",
-        data_config=config,
+        task_config=task_config,
     )
 
     final_task = pipeline.FinalizeCorpus(
         sample_rates=sample_rates,
         tasks_dir=tasks_dir,
         metadata=configure_metadata,
-        data_config=config,
+        task_config=task_config,
     )
     return final_task

--- a/heareval/tasks/util/luigi.py
+++ b/heareval/tasks/util/luigi.py
@@ -34,7 +34,7 @@ class WorkTask(luigi.Task):
     """
 
     # Class attribute sets the task name for all inheriting luigi tasks
-    data_config = luigi.DictParameter(
+    task_config = luigi.DictParameter(
         visibility=luigi.parameter.ParameterVisibility.PRIVATE
     )
 
@@ -70,7 +70,7 @@ class WorkTask(luigi.Task):
     @property
     def task_subdir(self):
         """Task specific subdirectory"""
-        return Path(self.data_config.get("luigi_dir", "_workdir")).joinpath(
+        return Path(self.task_config.get("luigi_dir", "_workdir")).joinpath(
             str(self.versioned_task_name)
         )
 
@@ -80,7 +80,7 @@ class WorkTask(luigi.Task):
         Versioned Task name contains the provided name in the
         data config and the version
         """
-        return f"{self.data_config['task_name']}-{self.data_config['version']}"
+        return f"{self.task_config['task_name']}-{self.task_config['version']}"
 
     @property
     def stage_number(self):

--- a/heareval/tasks/util/luigi.py
+++ b/heareval/tasks/util/luigi.py
@@ -198,7 +198,7 @@ def md5sum(filename):
     return d.hexdigest()
 
 
-def subsample_metadata(metadata: pd.DataFrame, max_files: int) -> pd.DataFrame:
+def subsample_labels(metadata: pd.DataFrame, max_files: int) -> pd.DataFrame:
     """
     Returns the sampled metadata
 

--- a/heareval/tasks/util/luigi.py
+++ b/heareval/tasks/util/luigi.py
@@ -198,7 +198,7 @@ def md5sum(filename):
     return d.hexdigest()
 
 
-def subsample_labels(metadata: pd.DataFrame, max_files: int) -> pd.DataFrame:
+def subsample_metadata(metadata: pd.DataFrame, max_files: int) -> pd.DataFrame:
     """
     Returns the sampled metadata
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -26,7 +26,7 @@ from heareval.tasks.util.luigi import subsample_metadata
             id="1. Test Stratify Key",
         ),
         # Tests - Stratification during Extreme imbalance in the label distribution.
-        # Expectation - By stratification the 2 labels will be picked up from the
+        # Expectation - By stratification the 2 metadata will be picked up from the
         # l2 and since l1 just has 1 sample, that will be picked up to ensure
         # we atleast have one instance of each stratify key
         pytest.param(


### PR DESCRIPTION
* Document how each of the steps of the preprocess pipeline works.
* MAX_TASK_DURATION_PER_SPLIT is 5 hours of audio for the entire dataset. dataset_fraction is gone.
* A handful of the tasks are renamed and clarified

Closes https://github.com/neuralaudio/hear-eval-kit/issues/193