### PR TITLE
[WIP] Test score sanity check

### DIFF
--- a/heareval/evaluation/task_evaluation.py
+++ b/heareval/evaluation/task_evaluation.py
@@ -24,7 +24,7 @@ def get_scene_based_prediction_files(
         task_path.joinpath("test.predicted-labels.pkl").open("rb")
     )
     if isinstance(predictions, torch.Tensor):
-        predictions = predictions.detach().numpy()
+        predictions = predictions.detach().cpu().numpy()
     elif isinstance(predictions, np.ndarray):
         pass
     else:

--- a/heareval/evaluation/task_evaluation.py
+++ b/heareval/evaluation/task_evaluation.py
@@ -68,6 +68,7 @@ def task_evaluation(task_path: Path):
     targets: Collection = []
     if embedding_type == "scene":
         predictions, targets = get_scene_based_prediction_files(task_path)
+        predictions, targets = np.array(predictions), np.array(targets)
     elif embedding_type == "event":
         predictions, targets = get_event_based_prediction_files(task_path)
     else:
@@ -81,7 +82,8 @@ def task_evaluation(task_path: Path):
         print("  -", score)
         # score_function = available_scores[score](metadata, label_to_idx)
         score_function = available_scores[score](label_to_idx=label_to_idx)
-        new_results = score_function(np.array(predictions), np.array(targets))
+        new_results = score_function(predictions, targets)
+        print("   ", new_results)
         results.update({score: new_results})
 
     return results

--- a/heareval/predictions/task_predictions.py
+++ b/heareval/predictions/task_predictions.py
@@ -511,7 +511,8 @@ def dataloader_from_split_name(
     )
 
     print(
-        f"Getting embeddings for split {split_name}, which has {len(split_name)} instances."
+        f"Getting embeddings for split {split_name}, "
+        + "which has {len(split_name)} instances."
     )
 
     return DataLoader(

--- a/heareval/predictions/task_predictions.py
+++ b/heareval/predictions/task_predictions.py
@@ -33,7 +33,12 @@ from sklearn.model_selection import ParameterGrid
 from torch.utils.data import DataLoader, Dataset
 from tqdm.auto import tqdm
 
-from heareval.score import ScoreFunction, available_scores, label_vocab_as_dict
+from heareval.score import (
+    ScoreFunction,
+    available_scores,
+    label_vocab_as_dict,
+    label_to_binary_vector,
+)
 
 PARAM_GRID = {
     "hidden_layers": [0, 1, 2],

--- a/heareval/predictions/task_predictions.py
+++ b/heareval/predictions/task_predictions.py
@@ -602,59 +602,6 @@ def task_predictions_train(
         )
 
 
-# This all needs to be cleaned up and simplified later.
-"""
-def task_predictions_test(
-    predictor: torch.nn.Module,
-    embedding_path: Path,
-    metadata: Dict[str, Any],
-    label_to_idx: Dict[str, int],
-    nlabels: int,
-):
-    dataloader = dataloader_from_split_name(
-        "test", embedding_path, label_to_idx, nlabels, metadata["embedding_type"]
-    )
-
-    all_predicted_labels = []
-    for embs, target_labels, filenames, timestamps in tqdm(dataloader):
-        predicted_labels = predictor(embs)
-        # TODO: Uses less memory to stack them one at a time
-        all_predicted_labels.append(predicted_labels)
-    predicted_labels = torch.cat(all_predicted_labels)
-
-    if metadata["embedding_type"] == "event":
-        # For event predictions we need to convert the frame-based predictions
-        # to a list of events with start and stop timestamps. These events are
-        # computed on each file independently and then saved as JSON in the same
-        # format as the ground truth events produced by the luigi pipeline.
-
-        # A list of filenames and timestamps associated with each prediction
-        file_timestamps = json.load(
-            embedding_path.joinpath("test.filename-timestamps.json").open()
-        )
-
-        # Can probably remove this stuff?
-
-        print("Creating events from predictions:")
-        # Probably don't need label_vocab any more since we have label_to_idx
-        label_vocab = pd.read_csv(embedding_path.joinpath("labelvocabulary.csv"))
-        events = get_events_for_all_files(
-            predicted_labels, file_timestamps, label_vocab
-        )
-
-        json.dump(
-            events,
-            embedding_path.joinpath("test.predictions.json").open("w"),
-            indent=4,
-        )
-
-    pickle.dump(
-        predicted_labels,
-        open(embedding_path.joinpath("test.predicted-labels.pkl"), "wb"),
-    )
-"""
-
-
 def task_predictions(
     embedding_path: Path, scene_embedding_size: int, timestamp_embedding_size: int
 ):
@@ -725,14 +672,3 @@ def task_predictions(
         best_predictor.test_predicted_labels,
         open(embedding_path.joinpath("test.predicted-labels.pkl"), "wb"),
     )
-
-    # TODO: Do something with me
-    """
-    task_predictions_test(
-        predictor=predictor,
-        embedding_path=embedding_path,
-        metadata=metadata,
-        label_to_idx=label_to_idx,
-        nlabels=nlabels,
-    )
-    """

--- a/heareval/predictions/task_predictions.py
+++ b/heareval/predictions/task_predictions.py
@@ -195,8 +195,8 @@ class ScenePredictionModel(AbstractPredictionModel):
             end_scores[f"{name}_{score}"] = score(
                 prediction.detach().cpu().numpy(), target.detach().cpu().numpy()
             )
-        for score in end_scores:
-            self.log(score, end_scores[score], prog_bar=True)
+        for score_name in end_scores:
+            self.log(score_name, end_scores[score_name], prog_bar=True)
         return end_scores
 
 
@@ -587,7 +587,10 @@ def task_predictions_train(
         "valid", embedding_path, label_to_idx, nlabels, metadata["embedding_type"]
     )
     trainer.fit(predictor, train_dataloader, valid_dataloader)
-    return predictor, trainer, checkpoint_callback.best_model_score.item(), mode
+    if checkpoint_callback.best_model_score:
+        return predictor, trainer, checkpoint_callback.best_model_score.item(), mode
+    else:
+        raise ValueError("No score for this model")
 
 
 # This all needs to be cleaned up and simplified later.

--- a/heareval/predictions/task_predictions.py
+++ b/heareval/predictions/task_predictions.py
@@ -104,7 +104,7 @@ class AbstractPredictionModel(pl.LightningModule):
         self.log("train_loss", loss)
         return loss
 
-    def validation_step(self, batch, batch_idx):
+    def _step(self, batch, batch_idx):
         # -> Dict[str, Union[torch.Tensor, List(str)]]:
         x, y, metadata = batch
         y_hat = self.predictor.forward_logit(x)
@@ -117,10 +117,22 @@ class AbstractPredictionModel(pl.LightningModule):
         # https://stackoverflow.com/questions/38987/how-do-i-merge-two-dictionaries-in-a-single-expression-taking-union-of-dictiona
         return {**z, **metadata}
 
+    def validation_step(self, batch, batch_idx):
+        return self._step(batch, batch_idx)
+
+    def test_step(self, batch, batch_idx):
+        return self._step(batch, batch_idx)
+
     # Implement this for each inheriting class
     # TODO: Can we combine the boilerplate for both of these?
-    def validation_epoch_end(self, outputs):
+    def _score_epoch_end(self, name: str, outputs: List[Dict[str, List[Any]]]):
         raise NotImplementedError("Implement this in children")
+
+    def validation_epoch_end(self, outputs: List[Dict[str, List[Any]]]):
+        self._score_epoch_end("val", outputs)
+
+    def test_epoch_end(self, outputs: List[Dict[str, List[Any]]]):
+        self._score_epoch_end("test", outputs)
 
     def _flatten_batched_outputs(
         self,
@@ -168,7 +180,7 @@ class ScenePredictionModel(AbstractPredictionModel):
             scores=scores,
         )
 
-    def validation_epoch_end(self, outputs):
+    def _score_epoch_end(self, name: str, outputs: List[Dict[str, List[Any]]]):
         flat_outputs = self._flatten_batched_outputs(
             outputs, keys=["target", "prediction", "prediction_logit"]
         )
@@ -177,10 +189,10 @@ class ScenePredictionModel(AbstractPredictionModel):
         )
 
         end_scores = {}
-        end_scores["val_loss"] = self.predictor.logit_loss(prediction_logit, target)
+        end_scores[f"{name}_loss"] = self.predictor.logit_loss(prediction_logit, target)
 
         for score in self.scores:
-            end_scores[f"val_{score}"] = score(
+            end_scores[f"{name}_{score}"] = score(
                 prediction.detach().cpu().numpy(), target.detach().cpu().numpy()
             )
         for score in end_scores:
@@ -203,6 +215,7 @@ class EventPredictionModel(AbstractPredictionModel):
         prediction_type: str,
         scores: List[ScoreFunction],
         validation_target_events: Dict[str, List[Dict[str, Any]]],
+        test_target_events: Dict[str, List[Dict[str, Any]]],
     ):
         super().__init__(
             nfeatures=nfeatures,
@@ -211,9 +224,12 @@ class EventPredictionModel(AbstractPredictionModel):
             prediction_type=prediction_type,
             scores=scores,
         )
-        self.validation_target_events = validation_target_events
+        self.target_events = {
+            "val": validation_target_events,
+            "test": test_target_events,
+        }
 
-    def validation_epoch_end(self, outputs: List[Dict[str, List[Any]]]):
+    def _score_epoch_end(self, name: str, outputs: List[Dict[str, List[Any]]]):
         flat_outputs = self._flatten_batched_outputs(
             outputs,
             keys=["target", "prediction", "prediction_logit", "filename", "timestamp"],
@@ -236,15 +252,15 @@ class EventPredictionModel(AbstractPredictionModel):
         )
 
         end_scores = {}
-        end_scores["val_loss"] = self.predictor.logit_loss(prediction_logit, target)
+        end_scores[f"{name}_loss"] = self.predictor.logit_loss(prediction_logit, target)
 
         for score in self.scores:
-            end_scores[f"val_{score}"] = score(
-                predicted_events, self.validation_target_events
+            end_scores[f"{name}_{score}"] = score(
+                predicted_events, self.target_events[name]
             )
             # Weird, this can happen if precision has zero guesses
-            if math.isnan(end_scores[f"val_{score}"]):
-                end_scores[f"val_{score}"] = 0.0
+            if math.isnan(end_scores[f"{name}_{score}"]):
+                end_scores[f"{name}_{score}"] = 0.0
         for score_name in end_scores:
             self.log(score_name, end_scores[score_name], prog_bar=True)
         return end_scores
@@ -486,16 +502,20 @@ def dataloader_from_split_name(
     embedding_type: str,
     batch_size: int = 64,
 ) -> DataLoader:
-    print(f"Getting embeddings for split: {split_name}")
+    dataset = SplitMemmapDataset(
+        embedding_path=embedding_path,
+        label_to_idx=label_to_idx,
+        nlabels=nlabels,
+        split_name=split_name,
+        embedding_type=embedding_type,
+    )
+
+    print(
+        f"Getting embeddings for split {split_name}, which has {len(split_name)} instances."
+    )
 
     return DataLoader(
-        SplitMemmapDataset(
-            embedding_path=embedding_path,
-            label_to_idx=label_to_idx,
-            nlabels=nlabels,
-            split_name=split_name,
-            embedding_type=embedding_type,
-        ),
+        dataset,
         batch_size=batch_size,
         # We don't shuffle because it's slow.
         # Also we want predicted labels in the same order as
@@ -511,12 +531,13 @@ def task_predictions_train(
     label_to_idx: Dict[str, int],
     nlabels: int,
     scores: List[ScoreFunction],
-) -> torch.nn.Module:
+) -> Tuple[torch.nn.Module, pl.Trainer, float, str]:
     predictor: AbstractPredictionModel
     if metadata["embedding_type"] == "event":
         validation_target_events = json.load(
             embedding_path.joinpath("valid.json").open()
         )
+        test_target_events = json.load(embedding_path.joinpath("test.json").open())
         predictor = EventPredictionModel(
             nfeatures=embedding_size,
             label_to_idx=label_to_idx,
@@ -524,6 +545,7 @@ def task_predictions_train(
             prediction_type=metadata["prediction_type"],
             scores=scores,
             validation_target_events=validation_target_events,
+            test_target_events=test_target_events,
         )
     elif metadata["embedding_type"] == "scene":
         predictor = ScenePredictionModel(
@@ -549,6 +571,7 @@ def task_predictions_train(
         monitor=target_score,
         min_delta=0.00,
         patience=50,
+        # patience=3,
         verbose=False,
         mode=mode,
     )
@@ -563,7 +586,7 @@ def task_predictions_train(
         "valid", embedding_path, label_to_idx, nlabels, metadata["embedding_type"]
     )
     trainer.fit(predictor, train_dataloader, valid_dataloader)
-    return predictor
+    return predictor, trainer, checkpoint_callback.best_model_score.item(), mode
 
 
 # This all needs to be cleaned up and simplified later.
@@ -638,15 +661,43 @@ def task_predictions(
         for score in metadata["evaluation"]
     ]
 
-    # predictor =
-    task_predictions_train(
-        embedding_path=embedding_path,
-        embedding_size=embedding_size,
-        metadata=metadata,
-        label_to_idx=label_to_idx,
-        nlabels=nlabels,
-        scores=scores,
+    mode = None
+    scores_and_trainers = []
+    # Model selection
+    for i in range(3):
+        # TODO: Assert mode doesn't change?
+        predictor, trainer, best_model_score, mode = task_predictions_train(
+            embedding_path=embedding_path,
+            embedding_size=embedding_size,
+            metadata=metadata,
+            label_to_idx=label_to_idx,
+            nlabels=nlabels,
+            scores=scores,
+        )
+        scores_and_trainers.append((best_model_score, trainer))
+
+    # Pick the model with the best validation score
+    scores_and_trainers.sort(key=lambda st: -st[0])
+    if mode == "max":
+        pass
+    elif mode == "min":
+        scores_and_trainers.reverse()
+    else:
+        raise ValueError(f"mode = {mode}")
+    # print(mode)
+    # print(scores_and_trainers)
+
+    # Use that model to compute test scores
+    best_score, best_trainer = scores_and_trainers[0]
+    print("Best validation score", best_score)
+    test_dataloader = dataloader_from_split_name(
+        "test", embedding_path, label_to_idx, nlabels, metadata["embedding_type"]
     )
+    test_scores = best_trainer.test(ckpt_path="best", test_dataloaders=test_dataloader)
+    open(embedding_path.joinpath("test.predicted-scores.json"), "wt").write(
+        json.dumps(test_scores, indent=4)
+    )
+
     # TODO: Do something with me
     """
     task_predictions_test(

--- a/heareval/score.py
+++ b/heareval/score.py
@@ -78,6 +78,7 @@ class Top1Accuracy(ScoreFunction):
             if predicted_class == target_class:
                 correct += 1
 
+        print("Score Top1Accuracy", correct / len(targets), correct, len(targets))
         return correct / len(targets)
 
 
@@ -103,6 +104,7 @@ class ChromaAccuracy(ScoreFunction):
             if predicted_class % 12 == target_class % 12:
                 correct += 1
 
+        print("Score ChromaAcc", correct / len(targets), correct, len(targets))
         return correct / len(targets)
 
 


### PR DESCRIPTION
https://github.com/neuralaudio/hear-eval-kit/pull/223 implements test scoring in the predictor runner.

We also have evaluation runner, which takes targets and prediction pickle files and scores them.

This is a good sanity check.

However, we are getting different scores in predictor than in runner. Perhaps the prediction is pickling the targets in the wrong order or something? Help!