### PR TITLE
[WIP] Update small datasets

### DIFF
--- a/heareval/tasks/speech_commands.py
+++ b/heareval/tasks/speech_commands.py
@@ -76,7 +76,12 @@ class GenerateTrainDataset(luigi_util.WorkTask):
     def run(self):
         train_path = Path(self.requires()["train"].workdir).joinpath("train")
         background_audio = list(train_path.glob(f"{BACKGROUND_NOISE}/*.wav"))
-        assert len(background_audio) > 0
+
+        # Remove the assertion below, as background noises might not be present 
+        # in the small version of the development dataset.
+        # Since the md5 check on the downloaded dataset is already present, 
+        # removing this is not a concern on data completeness.
+        # assert len(background_audio) > 0
 
         # Read all the background audio files and split into 1 second segments,
         # save all the segments into a folder called _silence_


### PR DESCRIPTION
This will update the small datasets for all the tasks.
Since the pipeline has changed over time, the small dataset must have also changed(deterministic)

- Remove the `len(background)>0` assert statement for speech command since we will not have any background.

Remaining is minor changes in the sampler for other tasks(to ensure we end up with at least one file for each split since we were using the stratify code(stratify on the split folder) to ensure this, and now the stratify piece is disabled.)