### PR TITLE
Scene evaluation targets as binary vector

### DIFF
--- a/heareval/evaluation/task_evaluation.py
+++ b/heareval/evaluation/task_evaluation.py
@@ -12,10 +12,12 @@ import numpy as np
 import pandas as pd
 import torch
 
-from heareval.score import available_scores, label_vocab_as_dict
+from heareval.score import available_scores, label_vocab_as_dict, label_to_binary_vector
 
 
-def get_scene_based_prediction_files(task_path: Path) -> Tuple[np.ndarray, List]:
+def get_scene_based_prediction_files(
+    task_path: Path, label_to_idx: Dict[str, str]
+) -> Tuple[np.ndarray, List]:
     # Predictions are currently torch tensors -- should we convert to np arrays before
     # pickling?
     predictions = pickle.load(
@@ -35,6 +37,16 @@ def get_scene_based_prediction_files(task_path: Path) -> Tuple[np.ndarray, List]
 
     # What other types could we receive as targets?
     assert isinstance(targets, list)
+
+    # Convert targets to binary vector
+    num_labels = len(label_to_idx)
+    binary_targets = []
+    for target in targets:
+        assert isinstance(target, list)
+        labels = [label_to_idx[str(label)] for label in target]
+        binary_targets.append(label_to_binary_vector(labels, num_labels))
+
+    targets = torch.vstack(binary_targets)
 
     # Make sure we have the same number of predictions as targets
     assert len(predictions) == len(targets)
@@ -58,6 +70,7 @@ def task_evaluation(task_path: Path):
 
     metadata = json.load(task_path.joinpath("task_metadata.json").open())
     label_vocab = pd.read_csv(task_path.joinpath("labelvocabulary.csv"))
+    label_to_idx = label_vocab_as_dict(label_vocab, key="label", value="idx")
 
     if "evaluation" not in metadata:
         print(f"Task {task_path.name} has no evaluation config.")
@@ -67,14 +80,14 @@ def task_evaluation(task_path: Path):
     predictions: Collection = []
     targets: Collection = []
     if embedding_type == "scene":
-        predictions, targets = get_scene_based_prediction_files(task_path)
+        predictions, targets = get_scene_based_prediction_files(
+            task_path, label_to_idx=label_to_idx
+        )
         predictions, targets = np.array(predictions), np.array(targets)
     elif embedding_type == "event":
         predictions, targets = get_event_based_prediction_files(task_path)
     else:
         raise ValueError(f"Unknown embedding type received: {embedding_type}")
-
-    label_to_idx = label_vocab_as_dict(label_vocab, key="label", value="idx")
 
     scores = metadata["evaluation"]
     results = {}

--- a/heareval/predictions/task_predictions.py
+++ b/heareval/predictions/task_predictions.py
@@ -352,8 +352,8 @@ class SplitMemmapDataset(Dataset):
         We also return the metadata as a Dict.
         """
         x = self.embedding_memmap[idx]
-        y = [self.label_to_idx[str(label)] for label in self.labels[idx]]
-        y = label_to_binary_vector(y, self.nlabels)
+        labels = [self.label_to_idx[str(label)] for label in self.labels[idx]]
+        y = label_to_binary_vector(labels, self.nlabels)
         return x, y, self.metadata[idx]
 
 

--- a/heareval/predictions/task_predictions.py
+++ b/heareval/predictions/task_predictions.py
@@ -32,7 +32,12 @@ from pytorch_lightning.callbacks.model_checkpoint import ModelCheckpoint
 from torch.utils.data import DataLoader, Dataset
 from tqdm.auto import tqdm
 
-from heareval.score import ScoreFunction, available_scores, label_vocab_as_dict
+from heareval.score import (
+    ScoreFunction,
+    available_scores,
+    label_vocab_as_dict,
+    label_to_binary_vector,
+)
 
 
 class OneHotToCrossEntropyLoss(torch.nn.Module):
@@ -348,24 +353,8 @@ class SplitMemmapDataset(Dataset):
         """
         x = self.embedding_memmap[idx]
         y = [self.label_to_idx[str(label)] for label in self.labels[idx]]
-        # Lame special case
-        if not y:
-            return (
-                x,
-                # BCEWithLogitsLoss wants float not long targets
-                torch.zeros((self.nlabels,), dtype=torch.int32).float(),
-                self.metadata[idx],
-            )
-        # TODO: Could rewrite faster using scatter_:
-        # https://discuss.pytorch.org/t/what-kind-of-loss-is-better-to-use-in-multilabel-classification/32203/4
-        return (
-            x,
-            # BCEWithLogitsLoss wants float not long targets
-            torch.nn.functional.one_hot(torch.LongTensor(y), num_classes=self.nlabels)
-            .max(axis=0)
-            .values.float(),
-            self.metadata[idx],
-        )
+        y = label_to_binary_vector(y, self.nlabels)
+        return x, y, self.metadata[idx]
 
 
 def create_events_from_prediction(


### PR DESCRIPTION
Created a function in score that converts a list of int labels to a one-hot / multi-hot binary vector. Both the prediction pipeline and the evaluation pipeline use this function now. Confirmed that prediction test scores now match the evaluation test scores.