### PR TITLE
Remove adding secret tasks to sys path

### DIFF
--- a/heareval/tasks/runner.py
+++ b/heareval/tasks/runner.py
@@ -22,7 +22,7 @@ try:
 
     secret_tasks = hearsecrettasks.tasks
 
-except ModuleNotFoundError as e:
+except ImportError as e:
     print(e)
     logger.info(
         "The hearsecrettask submodule is not installed. "

--- a/heareval/tasks/runner.py
+++ b/heareval/tasks/runner.py
@@ -19,10 +19,10 @@ logger = logging.getLogger("luigi-interface")
 # Currently the runner is only allowed to run for open tasks
 # The secret tasks module will be not be available for the participants
 try:
-    sys.path.append("heareval/tasks/secrettasks")
-    import hearsecrettasks
+    from heareval.tasks.secrettasks import hearsecrettasks
 
     secret_tasks = hearsecrettasks.tasks
+
 except ModuleNotFoundError as e:
     print(e)
     logger.info(

--- a/heareval/tasks/runner.py
+++ b/heareval/tasks/runner.py
@@ -5,7 +5,6 @@ Runs a luigi pipeline to build a dataset
 
 import logging
 import multiprocessing
-import sys
 from typing import Optional
 
 import click

--- a/heareval/tasks/sampler.py
+++ b/heareval/tasks/sampler.py
@@ -15,7 +15,6 @@ it simple to scale across multiple dataset
 import logging
 import multiprocessing
 import shutil
-import sys
 from pathlib import Path
 from typing import Optional
 from urllib.parse import urlparse
@@ -33,8 +32,7 @@ logger = logging.getLogger("luigi-interface")
 # Currently the sampler is only allowed to run for open tasks
 # The secret tasks module will not be available for participants
 try:
-    sys.path.append("heareval/tasks/secrettasks")
-    import hearsecrettasks
+    from heareval.tasks.secrettasks import hearsecrettasks
 
     secret_config = hearsecrettasks.sampler_config
 except ModuleNotFoundError as e:


### PR DESCRIPTION
When we add the secret paths to the sys.path in order to import it, it forces you to run heareval from the same directory that you clone the repo from. That can get a bit awkward. With the updates in the secret tasks repo the secret tasks package will now be accessible as a subpackage.