### PR TITLE
[WIP] Add Training for Data with Folds; Do full training on test and valid before final testing

### DIFF
--- a/heareval/predictions/task_predictions.py
+++ b/heareval/predictions/task_predictions.py
@@ -1068,14 +1068,14 @@ def data_splits_from_folds(folds: List[str]) -> List[Dict[str, List[str]]]:
     Total data splits will be equal to n, n being the total number of folds.
     Each fold will be tested by training on the remaining folds.
     """
-    folds = tuple(sorted(folds))
-    assert len(folds) == len(set(folds)), "Folds are not unique"
-    num_folds = len(folds)
+    sorted_folds: Tuple[str] = tuple(sorted(folds))
+    assert len(sorted_folds) == len(set(sorted_folds)), "Folds are not unique"
+    num_folds = len(sorted_folds)
     all_data_splits: List[Dict[str, List[str]]] = []
     for fold_idx in range(num_folds):
-        test_fold = folds[fold_idx]
-        valid_fold = folds[(fold_idx + 1) % num_folds]
-        train_folds = list(set(folds) - {test_fold, valid_fold})
+        test_fold = sorted_folds[fold_idx]
+        valid_fold = sorted_folds[(fold_idx + 1) % num_folds]
+        train_folds = list(set(sorted_folds) - {test_fold, valid_fold})
         all_data_splits.append(
             {
                 "train": train_folds,

--- a/heareval/predictions/task_predictions.py
+++ b/heareval/predictions/task_predictions.py
@@ -1068,7 +1068,7 @@ def data_splits_from_folds(folds: List[str]) -> List[Dict[str, List[str]]]:
     Total data splits will be equal to n, n being the total number of folds.
     Each fold will be tested by training on the remaining folds.
     """
-    sorted_folds: Tuple[str] = tuple(sorted(folds))
+    sorted_folds = tuple(sorted(folds))
     assert len(sorted_folds) == len(set(sorted_folds)), "Folds are not unique"
     num_folds = len(sorted_folds)
     all_data_splits: List[Dict[str, List[str]]] = []


### PR DESCRIPTION
This will

- Add methods to train and test on folds. Leave One out cross-validation strategy ( at a fold level ) will be applied. Each fold will be considered for testing, while all other folds will be used for training. This will lead to `n` sets of `data_splits`. Result for testing of each fold will be provided along with the aggregated result.
- Also, best grid point in the above case of `folds setup`, will only be found with the first `data_splits`. This will correspond to testing on the first fold(fold0), validation on second fold(fold1) and training on all other folds(fold2..). ( Sort the folds before deciding order(first or second) of the fold.
- For data with explicit `test, train and valid` splits defined,  best grid point will be found using the whole data.
- In both the above cases (data with folds or not with folds), the grid point will first be found followed by using this best grid point configuration to train on the `train+valid` set. Thereafter, the final testing scores will be computed.