### PR TITLE
Event labels as strigns

### DIFF
--- a/heareval/score.py
+++ b/heareval/score.py
@@ -190,7 +190,7 @@ class SoundEventScore(ScoreFunction):
                 reference_events.append(
                     {
                         # Convert from ms to seconds for sed_eval
-                        "event_label": event["label"],
+                        "event_label": str(event["label"]),
                         "event_onset": event["start"] / 1000.0,
                         "event_offset": event["end"] / 1000.0,
                         "file": filename,


### PR DESCRIPTION
sed_eval requires labels to be strings.