### PR TITLE
Fix event prediction model epochs

### DIFF
--- a/heareval/predictions/task_predictions.py
+++ b/heareval/predictions/task_predictions.py
@@ -460,13 +460,10 @@ class EventPredictionModel(AbstractPredictionModel):
             logger=True,
         )
 
+        epoch = self.current_epoch
         if name == "val":
-            # During training, the epoch is one behind the value that will
-            # be stored as the "best" epoch
-            epoch = self.current_epoch + 1
             postprocessing_cached = None
         elif name == "test":
-            epoch = self.current_epoch
             postprocessing_cached = self.epoch_best_postprocessing_or_default(epoch)
         else:
             raise ValueError

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ pynvml
 pytest
 pytest-cov
 pytest-env
-pytorch-lightning
+pytorch-lightning>=1.6
 python-slugify
 sed_eval
 soundfile

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
         "numpy==1.19.2",
         "pandas",
         "pynvml",
-        "pytorch-lightning",
+        "pytorch-lightning>=1.6",
         "python-slugify",
         "sed_eval",
         "soundfile",


### PR DESCRIPTION
In `_score_epoch_end`  in `EventPredictionModel` we had to account for a lag in the `current_epoch` during validation. See https://github.com/neuralaudio/hear-eval-kit/blob/f2868ab39edc3282fed2bbca997531b08f693c9c/heareval/predictions/task_predictions.py#L466

Due to an [update in PyTorch Lightning 1.6](https://github.com/PyTorchLightning/pytorch-lightning/pull/8578) the value of `current_epoch` is now update at the end of the training step, so we need to remove this.