### PR TITLE
PyTorch Lightning Version <= 1.5.10

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ pynvml
 pytest
 pytest-cov
 pytest-env
-pytorch-lightning
+pytorch-lightning<=1.5.10
 python-slugify
 sed_eval
 soundfile

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
         "numpy==1.19.2",
         "pandas",
         "pynvml",
-        "pytorch-lightning",
+        "pytorch-lightning<=1.5.10",
         "python-slugify",
         "sed_eval",
         "soundfile",


### PR DESCRIPTION
PyTorch Lightning 1.6 introduced some breaking changes. To make sure the codebase works as it is with minimal changes I pinned the PTL version to anything less than or equal to 1.5.10.